### PR TITLE
Corrected the spelling of scraped from "scaped"

### DIFF
--- a/resume.tex
+++ b/resume.tex
@@ -108,7 +108,7 @@
 	
 	\vspace{-5mm}
 	\cventry
-	{Scaped the inshorts news using beautiful soup library and used the Speech API for reading the scraped news}
+	{Scraped the inshorts news using beautiful soup library and used the Speech API for reading the scraped news}
 	{Inshorts Voice news}
 	{Python}
 	{}


### PR DESCRIPTION
I think you have made a spelling mistake, written "scaped" instead of "scraped".